### PR TITLE
Make rabbitmq host in queue-master configurable just like in shipping

### DIFF
--- a/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
+++ b/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
@@ -12,7 +12,7 @@ public class ShippingTaskHandler {
 
 	public void handleMessage(Shipment shipment) {
 		System.out.println("Received shipment task: " + shipment.getName());
-		//docker.init();
-		//docker.spawn();
+		docker.init();
+		docker.spawn();
 	}
 }

--- a/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
+++ b/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
@@ -8,11 +8,11 @@ import works.weave.socks.shipping.entities.Shipment;
 public class ShippingTaskHandler {
 
 	@Autowired
-	DockerSpawner docker;
+	//DockerSpawner docker;
 
 	public void handleMessage(Shipment shipment) {
 		System.out.println("Received shipment task: " + shipment.getName());
-		docker.init();
-		docker.spawn();
+		//docker.init();
+		//docker.spawn();
 	}
 }

--- a/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
+++ b/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
@@ -8,7 +8,7 @@ import works.weave.socks.shipping.entities.Shipment;
 public class ShippingTaskHandler {
 
 	@Autowired
-	//DockerSpawner docker;
+	DockerSpawner docker;
 
 	public void handleMessage(Shipment shipment) {
 		System.out.println("Received shipment task: " + shipment.getName());

--- a/src/main/java/works/weave/socks/queuemaster/configuration/RabbitMqConfiguration.java
+++ b/src/main/java/works/weave/socks/queuemaster/configuration/RabbitMqConfiguration.java
@@ -16,10 +16,14 @@ public class RabbitMqConfiguration
 {
     final static String queueName = "shipping-task";
 
+    @Value("${spring.rabbitmq.host}")
+    private String host;
+
+
     @Bean
     public ConnectionFactory connectionFactory()
     {
-        CachingConnectionFactory connectionFactory = new CachingConnectionFactory("rabbitmq");
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(host);
         connectionFactory.setCloseTimeout(5000);
         connectionFactory.setConnectionTimeout(5000);
         connectionFactory.setUsername("guest");

--- a/src/main/java/works/weave/socks/queuemaster/configuration/RabbitMqConfiguration.java
+++ b/src/main/java/works/weave/socks/queuemaster/configuration/RabbitMqConfiguration.java
@@ -19,7 +19,6 @@ public class RabbitMqConfiguration
     @Value("${spring.rabbitmq.host}")
     private String host;
 
-
     @Bean
     public ConnectionFactory connectionFactory()
     {

--- a/src/main/java/works/weave/socks/queuemaster/configuration/RabbitMqConfiguration.java
+++ b/src/main/java/works/weave/socks/queuemaster/configuration/RabbitMqConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.support.converter.DefaultClassMapper;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import works.weave.socks.shipping.entities.Shipment;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=${port:8080}
+spring.rabbitmq.host=rabbitmq
 endpoints.health.enabled=false


### PR DESCRIPTION
I'm submitting this pull request in connection with issue https://github.com/microservices-demo/microservices-demo/issues/686 and https://github.com/microservices-demo/queue-master/issues/16 which contains excerpts from the first.

The code changes are copied directly from shipping, so should not cause any problems.

I also just successfully ran ./test/test.sh unit.py and  ./test/test.sh component.py against the modified code in my cloned repository and both were successful, although the latter did give exception "org.springframework.amqp.AmqpIOException: java.net.UnknownHostException: rabbitmq" because there was no rabbitmq host on which rabbitmq could be listening.  But I think that's ok.