### PR TITLE
commented out spawning of Docker container

### DIFF
--- a/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
+++ b/src/main/java/works/weave/socks/queuemaster/ShippingTaskHandler.java
@@ -12,7 +12,7 @@ public class ShippingTaskHandler {
 
 	public void handleMessage(Shipment shipment) {
 		System.out.println("Received shipment task: " + shipment.getName());
-		docker.init();
-		docker.spawn();
+		//docker.init();
+		//docker.spawn();
 	}
 }


### PR DESCRIPTION
Now that my other pull request for making rabbitmq host configurable was accepted (for which I am grateful), I thought I would resubmit my proposed commenting out of the spawning of Docker container in queue-master.  The readme file does suggest that there are plans to remove this anyways.  My reason for wanting to comment it out is that the Docker container cannot be spawned on Apcera and Apcera users thus see exceptions in the queue-master log.

However, this is not by any means urgent.  Most Apcera users will probably never look at the queue-master log.  And if the microservices-demo team ultimately decides to keep the spawning of Docker, I will withdraw this pull request.

Thanks.